### PR TITLE
Updated example in Android Studio's tutorial

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
-    	<meta charset="utf-8">
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=Edge" /> 
         <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Merriweather:300">
         <link rel="icon" type="image/png" href="http://android.processing.org/favicon.png">
     	<link rel="stylesheet" href="css/main.css">

--- a/install.html
+++ b/install.html
@@ -2,6 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
         <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Merriweather:300">
         <link rel="icon" type="image/png" href="http://android.processing.org/favicon.png">
         <link rel="stylesheet" href="css/main.css">

--- a/libraries.html
+++ b/libraries.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
-        <meta charset="utf-8">
+      <meta charset="utf-8">      
+        <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
         <meta name="Author" content="Casey Reas &amp; Ben Fry with Android Mode text by Andres Colubri">
         <meta name="Publisher" content="Processing Foundation">
         <meta name="Keywords" content="Processing, Interactive Media, Electronic Arts, Programming, Java, Ben Fry, Casey Reas, Android">

--- a/reference/environment/activity.html
+++ b/reference/environment/activity.html
@@ -2,6 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
         <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Merriweather:300">
         <link rel="icon" type="image/png" href="http://android.processing.org/favicon.png">
         <link rel="stylesheet" href="../../css/main.css">

--- a/reference/environment/display.html
+++ b/reference/environment/display.html
@@ -2,6 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
         <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Merriweather:300">
         <link rel="icon" type="image/png" href="http://android.processing.org/favicon.png">
         <link rel="stylesheet" href="../../css/main.css">

--- a/reference/environment/orientation.html
+++ b/reference/environment/orientation.html
@@ -2,6 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
         <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Merriweather:300">
         <link rel="icon" type="image/png" href="http://android.processing.org/favicon.png">
         <link rel="stylesheet" href="../../css/main.css">

--- a/reference/gone.html
+++ b/reference/gone.html
@@ -2,6 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
         <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Merriweather:300">
         <link rel="icon" type="image/png" href="http://android.processing.org/favicon.png">
         <link rel="stylesheet" href="../css/main.css">

--- a/reference/index.html
+++ b/reference/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
         <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Merriweather:300">
         <link rel="icon" type="image/png" href="http://android.processing.org/favicon.png">
         <link rel="stylesheet" href="../css/main.css">

--- a/reference/multitouch/events.html
+++ b/reference/multitouch/events.html
@@ -2,6 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
         <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Merriweather:300">
         <link rel="icon" type="image/png" href="http://android.processing.org/favicon.png">
         <link rel="stylesheet" href="../../css/main.css">

--- a/reference/multitouch/touches.html
+++ b/reference/multitouch/touches.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
-        <meta charset="utf-8">      
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=Edge" />      
         <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Merriweather:300">
         <link rel="icon" type="image/png" href="http://android.processing.org/favicon.png">
         <link rel="stylesheet" href="../../css/main.css">

--- a/reference/permissions/query.html
+++ b/reference/permissions/query.html
@@ -2,6 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
         <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Merriweather:300">
         <link rel="icon" type="image/png" href="http://android.processing.org/favicon.png">
         <link rel="stylesheet" href="../../css/main.css">

--- a/reference/permissions/request.html
+++ b/reference/permissions/request.html
@@ -2,6 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
         <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Merriweather:300">
         <link rel="icon" type="image/png" href="http://android.processing.org/favicon.png">
         <link rel="stylesheet" href="../../css/main.css">

--- a/reference/vr/camera.html
+++ b/reference/vr/camera.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
-        <meta charset="utf-8">      
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=Edge" />      
         <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Merriweather:300">
         <link rel="icon" type="image/png" href="http://android.processing.org/favicon.png">
         <link rel="stylesheet" href="../../css/main.css">

--- a/reference/vr/eye.html
+++ b/reference/vr/eye.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
-        <meta charset="utf-8">      
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=Edge" />      
         <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Merriweather:300">
         <link rel="icon" type="image/png" href="http://android.processing.org/favicon.png">
         <link rel="stylesheet" href="../../css/main.css">

--- a/reference/vr/eyeType.html
+++ b/reference/vr/eyeType.html
@@ -2,6 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
         <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Merriweather:300">
         <link rel="icon" type="image/png" href="http://android.processing.org/favicon.png">
         <link rel="stylesheet" href="../../css/main.css">

--- a/reference/vr/object.html
+++ b/reference/vr/object.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
-        <meta charset="utf-8">      
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=Edge" />      
         <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Merriweather:300">
         <link rel="icon" type="image/png" href="http://android.processing.org/favicon.png">
         <link rel="stylesheet" href="../../css/main.css">

--- a/reference/vr/renderers.html
+++ b/reference/vr/renderers.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
-        <meta charset="utf-8">      
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=Edge" />      
         <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Merriweather:300">
         <link rel="icon" type="image/png" href="http://android.processing.org/favicon.png">
         <link rel="stylesheet" href="../../css/main.css">

--- a/reference/wallpapers/offset.html
+++ b/reference/wallpapers/offset.html
@@ -2,6 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
         <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Merriweather:300">
         <link rel="icon" type="image/png" href="http://android.processing.org/favicon.png">
         <link rel="stylesheet" href="../../css/main.css">

--- a/reference/wallpapers/preview.html
+++ b/reference/wallpapers/preview.html
@@ -2,6 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
         <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Merriweather:300">
         <link rel="icon" type="image/png" href="http://android.processing.org/favicon.png">
         <link rel="stylesheet" href="../../css/main.css">

--- a/reference/wear/insets.html
+++ b/reference/wear/insets.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
-        <meta charset="utf-8">       
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=Edge" />       
         <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Merriweather:300">
         <link rel="icon" type="image/png" href="http://android.processing.org/favicon.png">
         <link rel="stylesheet" href="../../css/main.css">

--- a/reference/wear/mode.html
+++ b/reference/wear/mode.html
@@ -2,6 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
         <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Merriweather:300">
         <link rel="icon" type="image/png" href="http://android.processing.org/favicon.png">
         <link rel="stylesheet" href="../../css/main.css">

--- a/reference/wear/shape.html
+++ b/reference/wear/shape.html
@@ -2,6 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
         <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Merriweather:300">
         <link rel="icon" type="image/png" href="http://android.processing.org/favicon.png">
         <link rel="stylesheet" href="../../css/main.css">

--- a/reference/wear/special.html
+++ b/reference/wear/special.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
-        <meta charset="utf-8">       
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=Edge" />       
         <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Merriweather:300">
         <link rel="icon" type="image/png" href="http://android.processing.org/favicon.png">
         <link rel="stylesheet" href="../../css/main.css">

--- a/team.html
+++ b/team.html
@@ -2,6 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
         <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Merriweather:300">
         <link rel="icon" type="image/png" href="http://android.processing.org/favicon.png">
         <link rel="stylesheet" href="css/main.css">

--- a/tutorials/android_studio/index.html
+++ b/tutorials/android_studio/index.html
@@ -150,7 +150,6 @@ import android.widget.FrameLayout;
 import android.support.v7.app.AppCompatActivity;
 
 import processing.android.PFragment;
-import processing.android.ViewIdGenerator;
 import processing.core.PApplet;
 
 public class MainActivity extends AppCompatActivity {
@@ -160,14 +159,15 @@ public class MainActivity extends AppCompatActivity {
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     FrameLayout frame = new FrameLayout(this);
-    frame.setId(ViewIdGenerator.getUniqueId());
+    frame.setId(View.generateViewId());
     setContentView(frame, 
       new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
                                  ViewGroup.LayoutParams.MATCH_PARENT));
 
     sketch = new Sketch();
     PFragment fragment = new PFragment(sketch);
-    fragment.setView(frame, this);
+    PFragment fragment = new PFragment();
+    fragment.setSketch(sketch, frame, getSupportFragmentManager());
   }
 
   @Override

--- a/tutorials/android_studio/index.html
+++ b/tutorials/android_studio/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
         <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Merriweather:300">
         <link rel="icon" type="image/png" href="http://android.processing.org/favicon.png">
         <link rel="stylesheet" href="../../css/main.css">

--- a/tutorials/distributing/index.html
+++ b/tutorials/distributing/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
         <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Merriweather:300">
         <link rel="icon" type="image/png" href="http://android.processing.org/favicon.png">
         <link rel="stylesheet" href="../../css/main.css">

--- a/tutorials/getting_started/index.html
+++ b/tutorials/getting_started/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
         <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Merriweather:300">
         <link rel="icon" type="image/png" href="http://android.processing.org/favicon.png">
         <link rel="stylesheet" href="../../css/main.css">

--- a/tutorials/index.html
+++ b/tutorials/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
         <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Merriweather:300">
         <link rel="icon" type="image/png" href="http://android.processing.org/favicon.png">
         <link rel="stylesheet" href="../css/main.css">

--- a/tutorials/location/index.html
+++ b/tutorials/location/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
         <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Merriweather:300">
         <link rel="icon" type="image/png" href="http://android.processing.org/favicon.png">
         <link rel="stylesheet" href="../../css/main.css">

--- a/tutorials/sensors/index.html
+++ b/tutorials/sensors/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
         <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Merriweather:300">
         <link rel="icon" type="image/png" href="http://android.processing.org/favicon.png">
         <link rel="stylesheet" href="../../css/main.css">

--- a/tutorials/vr_advanced/index.html
+++ b/tutorials/vr_advanced/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
         <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Merriweather:300">
         <link rel="icon" type="image/png" href="http://android.processing.org/favicon.png">
         <link rel="stylesheet" href="../../css/main.css">

--- a/tutorials/vr_intro/index.html
+++ b/tutorials/vr_intro/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
         <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Merriweather:300">
         <link rel="icon" type="image/png" href="http://android.processing.org/favicon.png">
         <link rel="stylesheet" href="../../css/main.css">

--- a/tutorials/wallpapers/index.html
+++ b/tutorials/wallpapers/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
         <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Merriweather:300">
         <link rel="icon" type="image/png" href="http://android.processing.org/favicon.png">
         <link rel="stylesheet" href="../../css/main.css">

--- a/tutorials/watchfaces/index.html
+++ b/tutorials/watchfaces/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
         <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Merriweather:300">
         <link rel="icon" type="image/png" href="http://android.processing.org/favicon.png">
         <link rel="stylesheet" href="../../css/main.css">


### PR DESCRIPTION
Updated provided example in the Processing Android's webpage to match current AS template.  To consider, View.generateViewId() requires API 17 so I get from the AS interface. Nevertheless, these changes match the current template.